### PR TITLE
make auth header option based on github token

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/getReleases.js
+++ b/src/getReleases.js
@@ -6,12 +6,17 @@ const { GITHUB_TOKEN } = process.env;
 export default async function getReleases(user, repo) {
   const url = `https://api.github.com/repos/${user}/${repo}/releases`;
 
-  const r = await got.get(url, {
+  const requestConfig = {
     headers: {
-      'User-Agent': name,
-      Authorization: `token ${GITHUB_TOKEN}`,
+      'User-Agent': name
     },
     responseType: 'json'
-  });
+  };
+
+  if (GITHUB_TOKEN) {
+    requestConfig.headers.Authorization = `token ${GITHUB_TOKEN}`;
+  }
+
+  const r = await got.get(url, requestConfig);
   return r.body;
 }


### PR DESCRIPTION
This appears to resolve the 401 errors that I reported here:

https://github.com/terascope/fetch-github-release/issues/88

I've not built or released this package before but I bumped the patch revision and I think if I create a github release after merging it will automatically build and release an NPM package.  Then we'd need to bump the dependency in teraslice-cli.