### PR TITLE
Check for null releases list

### DIFF
--- a/src/getLatest.js
+++ b/src/getLatest.js
@@ -3,6 +3,10 @@ function pass() {
 }
 
 export default function getLatest(releases, filterRelease = pass, filterAsset = pass) {
+  if (!releases) {
+    return null;
+  }
+  
   const filtered = releases.filter(filterRelease);
 
   if (!filtered.length) {


### PR DESCRIPTION
I've observed this in the original repo (which is why I looked at the forks and found your now better maintained repo).