### PR TITLE
v0.7.7 - Ensure output dir exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Download a specific release from github",
   "main": "lib/index.js",
   "typings": "index.d.ts",

--- a/src/downloadRelease.js
+++ b/src/downloadRelease.js
@@ -16,7 +16,7 @@ const MultiProgress = require('multi-progress');
 async function downloadRelease(
   user,
   repo,
-  outputDir,
+  _outputDir,
   filterRelease = pass,
   filterAsset = pass,
   leaveZipped = false,
@@ -45,6 +45,15 @@ async function downloadRelease(
         total: 100
       });
       progress = bar.update.bind(bar);
+    }
+
+    const outputDir = path.isAbsolute(_outputDir) ? _outputDir : path.resolve(_outputDir);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir);
+    }
+
+    if (!fs.statSync(outputDir).isDirectory()) {
+      throw new Error(`Output path "${outputDir}" must be a directory`);
     }
 
     const destf = path.join(outputDir, asset.name);


### PR DESCRIPTION
Ensure that the output directory exists before unzipping to avoid an error. Closes #156 