### PR TITLE
Export got http error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Download a specific release from github",
   "files": [
     "dist/src/**/*",

--- a/src/getReleases.ts
+++ b/src/getReleases.ts
@@ -20,3 +20,5 @@ export async function getReleases(user: string, repo: string): Promise<GithubRel
     const r = await got.get<GithubRelease[]>(url, requestConfig);
     return r.body;
 }
+
+export { HTTPError } from 'got';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { downloadRelease } from './downloadRelease';
 import { HTTPError } from './getReleases';
 
-export { downloadRelease };
-export { HTTPError };
+export { downloadRelease, HTTPError };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { downloadRelease } from './downloadRelease';
+import { HTTPError } from './getReleases';
 
 export { downloadRelease };
+export { HTTPError };


### PR DESCRIPTION
Export `got.HTTPError`. This will allow for better error handling, specifically in the case where github rate limits are exceeded and it is necessary to read HTTPError.response.headers to determine the backoff. 