### PR TITLE
bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Download a specific release from github",
   "type": "module",
   "files": [
@@ -67,5 +67,8 @@
     "tmp": "0.2.3",
     "ts-jest": "^29.2.4",
     "typescript": "^5.2.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps the version to 2.0.0 so we can make a release.
Updating `got` bumps the minimum node version to 16.
It also adds `engines.node: >=18.0.0` to the package.json, as this is the lowest node version that we test.