### PR TITLE
[feat] Add dry-run parameter 

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ const command = await yargs(hideBin(process.argv))
         default: false
     })
     .option('output', {
-        description: 'type of output returned',
+        description: 'return dry-run information in either text or json format',
         type: 'string',
         alias: 'o',
         default: 'text',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { downloadRelease } from './downloadRelease.js';
-import { GithubRelease, GithubReleaseAsset, ReleaseInfo } from './interfaces.js';
+import { GithubRelease, GithubReleaseAsset } from './interfaces.js';
 
 const command = await yargs(hideBin(process.argv))
     .alias('h', 'help')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,24 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { downloadRelease } from './downloadRelease.js';
-import { GithubRelease, GithubReleaseAsset } from './interfaces.js';
+import { GithubRelease, GithubReleaseAsset, ReleaseInfo } from './interfaces.js';
 
 const command = await yargs(hideBin(process.argv))
     .alias('h', 'help')
     .alias('v', 'version')
+    .option('dry-run', {
+        description: 'list metadata instead of downloading',
+        type: 'boolean',
+        alias: 'd',
+        default: false
+    })
+    .option('output', {
+        description: 'type of output returned',
+        type: 'string',
+        alias: 'o',
+        default: 'text',
+        choices: ['json', 'text']
+    })
     .option('prerelease', {
         description: 'download prerelease',
         type: 'boolean',
@@ -18,7 +31,7 @@ const command = await yargs(hideBin(process.argv))
         type: 'string',
     })
     .option('quiet', {
-        description: 'don\'t log to console',
+        description: 'don\'t log to console, if dry-run is enabled, will only list release',
         type: 'boolean',
         alias: 'q',
         default: false
@@ -68,7 +81,9 @@ downloadRelease(
     filterRelease,
     filterAsset,
     !!command.zipped,
-    !!command.quiet
+    !!command.quiet,
+    !!command.dryRun,
+    command.output
 )
     .catch((err) => {
         console.error(err);

--- a/src/downloadRelease.ts
+++ b/src/downloadRelease.ts
@@ -105,16 +105,14 @@ export async function downloadRelease(
         const dryRunInfo: ReleaseInfo = {
             release: `${user}/${repo}@${release.tag_name}`,
             assetFileNames: await Promise.all(promises)
-        }
+        };
 
         /// Give only the release string in the case
         // that quiet is enabled
         if (disableLogging && output === 'text') {
             process.stdout.write(`${dryRunInfo.release}\n`);
-
         } else if (disableLogging && output === 'json') {
             process.stdout.write(`${JSON.stringify(dryRunInfo.release, null, 2)}\n`);
-
         } else {
             printDryRunInfo(dryRunInfo, output);
         }
@@ -136,7 +134,7 @@ function printDryRunInfo(data: ReleaseInfo, output: string): void {
         const prompt = [
             `Release: ${data.release}\n`,
             'The following files would have been downloaded:\n',
-            ...data.assetFileNames.map(file => `- ${file}`),
+            ...data.assetFileNames.map((file) => `- ${file}`),
         ].join('\n');
         process.stdout.write(`${prompt}\n`);
     } else if (output === 'json') {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,3 +26,10 @@ export interface GithubReleaseAsset {
     created_at: string;
     updated_at: string;
 }
+/**
+ * JSON object for printing dry-run
+ */
+export interface ReleaseInfo {
+    release: string,
+    assetFileNames: string[]
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,6 @@ export interface GithubReleaseAsset {
  * JSON object for printing dry-run
  */
 export interface ReleaseInfo {
-    release: string,
-    assetFileNames: string[]
+    release: string;
+    assetFileNames: string[];
 }


### PR DESCRIPTION
This PR makes the following changes:

- Adds `dry-run` parameter and `output` parameter to the cli
  - `dry-run` will allow the user to run the command gather metadata on what was filtered from the github api
    - `dry-run` will display only the release name in the case that `-q quiet` is also enabled
  - `output` accepts either `json` or `text`(default) for the user to choose what format the dry-run info will printed in stdout