### PR TITLE
Debug release workflow npm auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,5 +26,3 @@ jobs:
           echo "Check NPM Authentication"
           yarn npm whoami
       - run: yarn npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Retrieve version
         run : echo "NEW_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
         id: version
+      - run:
+          echo "Check NPM Authentication"
+          yarn npm whoami
       - run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Download a specific release from github",
   "type": "module",
   "files": [


### PR DESCRIPTION
This PR makes the following changes:
- add `whoami` step to the release.yml to debug npm auth.
- bump (patch) from 2.2.0 to 2.2.1 to allow release retry 