### PR TITLE
bundled dependency updates for 6-9-2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,15 +49,15 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@terascope/eslint-config": "^1.1.16",
+    "@terascope/eslint-config": "^1.1.17",
     "@types/jest": "^29.5.14",
     "@types/multi-progress": "^2.0.6",
-    "@types/node": "^22.15.29",
+    "@types/node": "^22.15.30",
     "@types/stream-buffers": "^3.0.7",
     "@types/tmp": "^0.2.6",
     "eslint": "^9.28.0",
     "jest": "^29.7.0",
-    "jest-extended": "^5.0.3",
+    "jest-extended": "^6.0.0",
     "nock": "^14.0.5",
     "node-notifier": "^10.0.1",
     "rimraf": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,14 +829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.27.0, @eslint/js@npm:~9.27.0":
-  version: 9.27.0
-  resolution: "@eslint/js@npm:9.27.0"
-  checksum: 10c0/79b219ceda79182732954b52f7a494f49995a9a6419c7ae0316866e324d3706afeb857e1306bb6f35a4caaf176a5174d00228fc93d36781a570d32c587736564
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.28.0":
+"@eslint/js@npm:9.28.0, @eslint/js@npm:~9.28.0":
   version: 9.28.0
   resolution: "@eslint/js@npm:9.28.0"
   checksum: 10c0/5a6759542490dd9f778993edfbc8d2f55168fd0f7336ceed20fe3870c65499d72fc0bca8d1ae00ea246b0923ea4cba2e0758a8a5507a3506ddcf41c92282abb8
@@ -1377,27 +1370,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "@terascope/eslint-config@npm:1.1.16"
+"@terascope/eslint-config@npm:^1.1.17":
+  version: 1.1.17
+  resolution: "@terascope/eslint-config@npm:1.1.17"
   dependencies:
     "@eslint/compat": "npm:~1.2.9"
-    "@eslint/js": "npm:~9.27.0"
+    "@eslint/js": "npm:~9.28.0"
     "@stylistic/eslint-plugin": "npm:~4.4.0"
-    "@typescript-eslint/eslint-plugin": "npm:~8.33.0"
-    "@typescript-eslint/parser": "npm:~8.33.0"
-    eslint: "npm:~9.27.0"
+    "@typescript-eslint/eslint-plugin": "npm:~8.33.1"
+    "@typescript-eslint/parser": "npm:~8.33.1"
+    eslint: "npm:~9.28.0"
     eslint-plugin-import: "npm:~2.31.0"
-    eslint-plugin-jest: "npm:~28.11.1"
+    eslint-plugin-jest: "npm:~28.12.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-react: "npm:~7.37.5"
     eslint-plugin-react-hooks: "npm:~5.2.0"
-    eslint-plugin-testing-library: "npm:~7.2.2"
+    eslint-plugin-testing-library: "npm:~7.3.0"
     globals: "npm:~16.2.0"
     typescript: "npm:~5.8.3"
-    typescript-eslint: "npm:~8.33.0"
-  checksum: 10c0/f4c3e21b6c862d182bc625cd61d148012089427c47275676b82b30acb5cc3b07134f3b0e1229b47d062701b421292110beba233b3a4bd3e5c49690814c662fb6
+    typescript-eslint: "npm:~8.33.1"
+  checksum: 10c0/44be4adc6165e4ee3002864d056ce67f52e0ff0ac9514bc4bbe4be282d7149b5ad0000b6b505a2ec5432c75e6d184081d17e19fef63c0e038f74410781c6e58a
   languageName: node
   linkType: hard
 
@@ -1405,17 +1398,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/fetch-github-release@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:^1.1.16"
+    "@terascope/eslint-config": "npm:^1.1.17"
     "@types/jest": "npm:^29.5.14"
     "@types/multi-progress": "npm:^2.0.6"
-    "@types/node": "npm:^22.15.29"
+    "@types/node": "npm:^22.15.30"
     "@types/stream-buffers": "npm:^3.0.7"
     "@types/tmp": "npm:^0.2.6"
     eslint: "npm:^9.28.0"
     extract-zip: "npm:^2.0.1"
     got: "npm:14.4.7"
     jest: "npm:^29.7.0"
-    jest-extended: "npm:^5.0.3"
+    jest-extended: "npm:^6.0.0"
     multi-progress: "npm:^4.0.0"
     nock: "npm:^14.0.5"
     node-notifier: "npm:^10.0.1"
@@ -1570,12 +1563,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.15.29":
-  version: 22.15.29
-  resolution: "@types/node@npm:22.15.29"
+"@types/node@npm:^22.15.30":
+  version: 22.15.30
+  resolution: "@types/node@npm:22.15.30"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/602cc88c6150780cd9b5b44604754e0ce13983ae876a538861d6ecfb1511dff289e5576fffd26c841cde2142418d4bb76e2a72a382b81c04557ccb17cff29e1d
+  checksum: 10c0/ca330ac0e7fd502686d6df115fcc606aba46fd334220f749bbba2f639accdadcb23f7900603ceccdc8240be736739cad5c0b87c0fa92c9255a4dff245f07d664
   languageName: node
   linkType: hard
 
@@ -1636,7 +1629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.33.1, @typescript-eslint/eslint-plugin@npm:~8.33.0":
+"@typescript-eslint/eslint-plugin@npm:8.33.1, @typescript-eslint/eslint-plugin@npm:~8.33.1":
   version: 8.33.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.33.1"
   dependencies:
@@ -1657,7 +1650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.33.1, @typescript-eslint/parser@npm:~8.33.0":
+"@typescript-eslint/parser@npm:8.33.1, @typescript-eslint/parser@npm:~8.33.1":
   version: 8.33.1
   resolution: "@typescript-eslint/parser@npm:8.33.1"
   dependencies:
@@ -3065,9 +3058,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:~28.11.1":
-  version: 28.11.2
-  resolution: "eslint-plugin-jest@npm:28.11.2"
+"eslint-plugin-jest@npm:~28.12.0":
+  version: 28.12.0
+  resolution: "eslint-plugin-jest@npm:28.12.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
   peerDependencies:
@@ -3079,7 +3072,7 @@ __metadata:
       optional: true
     jest:
       optional: true
-  checksum: 10c0/3fdad96bf2532f4922511a78fb59f5662410dd01e183cce0cb2792c6d78009d2dff2d3fb2fe09e13b2776dc20ee80f955111af9816c4605c7275c7f89385e255
+  checksum: 10c0/1072070921e0329bd8a369fea6017de930d942387ef325bc656301812d08d8a9dcd862284493d57c0a52b4bd73128f2157e010116f5efe7bf626c61a78f0a2d8
   languageName: node
   linkType: hard
 
@@ -3145,15 +3138,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:~7.2.2":
-  version: 7.2.2
-  resolution: "eslint-plugin-testing-library@npm:7.2.2"
+"eslint-plugin-testing-library@npm:~7.3.0":
+  version: 7.3.0
+  resolution: "eslint-plugin-testing-library@npm:7.3.0"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^8.15.0"
     "@typescript-eslint/utils": "npm:^8.15.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/51b5b6a3bb6b08c0e1fbb90678b701e94d20b0493bf5572f217cf75b13ac54e813ad0595537e2c8254589d977cb719aa4610d5aac4c1def6510a69c52fcfe908
+  checksum: 10c0/febd1823838813bf5ebd122d1da97b3059c181a9586cc8b378870d20d27383342c4536ae86d51a4c2a95b1085167cdf951a5c83ff22c6087d7e9357a10e986a5
   languageName: node
   linkType: hard
 
@@ -3181,7 +3174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.28.0":
+"eslint@npm:^9.28.0, eslint@npm:~9.28.0":
   version: 9.28.0
   resolution: "eslint@npm:9.28.0"
   dependencies:
@@ -3228,56 +3221,6 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: 10c0/513ea7e69d88a0905d4ed35cef3a8f31ebce7ca9f2cdbda3474495c63ad6831d52357aad65094be7a144d6e51850980ced7d25efb807e8ab06a427241f7cd730
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.27.0":
-  version: 9.27.0
-  resolution: "eslint@npm:9.27.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.20.0"
-    "@eslint/config-helpers": "npm:^0.2.1"
-    "@eslint/core": "npm:^0.14.0"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.27.0"
-    "@eslint/plugin-kit": "npm:^0.3.1"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.3.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/135d301e37cd961000a9c1d3f0e1863bed29a61435dfddedba3db295973193024382190fd8790a8de83777d10f450082a29eaee8bc9ce0fb1bc1f2b0bb882280
   languageName: node
   linkType: hard
 
@@ -4663,17 +4606,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-extended@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "jest-extended@npm:5.0.3"
+"jest-extended@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "jest-extended@npm:6.0.0"
   dependencies:
     jest-diff: "npm:^29.0.0"
   peerDependencies:
     jest: ">=27.2.5"
+    typescript: ">=5.0.0"
   peerDependenciesMeta:
     jest:
       optional: true
-  checksum: 10c0/37b80f90be141e2bb3344346962e435e6b8c5a121d5c6ad89865b07ff9f0810c2f273eb7ea4c00d3fc71a07667fee4da100c2190f180ae3662d023c19e24146a
+    typescript:
+      optional: false
+  checksum: 10c0/e729828f69ac6689e532608fde4afc45b275262ffb5660d458eb141dd572575864861b614be2573268914570d321521775710ae0866aa5834655a042e257ce17
   languageName: node
   linkType: hard
 
@@ -6975,7 +6921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.33.0":
+"typescript-eslint@npm:~8.33.1":
   version: 8.33.1
   resolution: "typescript-eslint@npm:8.33.1"
   dependencies:


### PR DESCRIPTION
This PR updates the following packages:
  - devDependencies
    - @terascope/eslint-config from 1.1.16 to 1.1.17
    - @types/node from 22.15.29 to 22.15.30
    - jest-extended from 5.0.3 to 6.0.0