### PR TITLE
Bundled dependency updates for 6-23-2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,14 +49,14 @@
     "yargs": "^18.0.0"
   },
   "devDependencies": {
-    "@terascope/eslint-config": "^1.1.17",
+    "@terascope/eslint-config": "^1.1.18",
     "@types/jest": "^30.0.0",
     "@types/multi-progress": "^2.0.6",
     "@types/node": "^24.0.3",
     "@types/stream-buffers": "^3.0.7",
     "@types/tmp": "^0.2.6",
     "eslint": "^9.29.0",
-    "jest": "^30.0.0",
+    "jest": "^30.0.2",
     "jest-extended": "^6.0.0",
     "nock": "^14.0.5",
     "node-notifier": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,26 +717,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:~1.2.9":
-  version: 1.2.9
-  resolution: "@eslint/compat@npm:1.2.9"
+"@eslint/compat@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "@eslint/compat@npm:1.3.0"
   peerDependencies:
     eslint: ^9.10.0
   peerDependenciesMeta:
     eslint:
       optional: true
-  checksum: 10c0/e912058f1e3847a1eec654c0c040467b676bd48171e915c730c7215f57cf5f4db8508c4a431ccb470f4a000d94559b41c4fe8de3d71f23eb8ae7acf4959e1c06
-  languageName: node
-  linkType: hard
-
-"@eslint/config-array@npm:^0.20.0":
-  version: 0.20.0
-  resolution: "@eslint/config-array@npm:0.20.0"
-  dependencies:
-    "@eslint/object-schema": "npm:^2.1.6"
-    debug: "npm:^4.3.1"
-    minimatch: "npm:^3.1.2"
-  checksum: 10c0/94bc5d0abb96dc5295ff559925242ff75a54eacfb3576677e95917e42f7175e1c4b87bf039aa2a872f949b4852ad9724bf2f7529aaea6b98f28bb3fca7f1d659
+  checksum: 10c0/991f431811eea683567f351653cf27972ce9443e4edd3f1f0abac09336fc21be0a0ba20b2ae9e9094023738be71050eaaafc529d0a85283e61895d16afa65d97
   languageName: node
   linkType: hard
 
@@ -784,14 +773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.28.0, @eslint/js@npm:~9.28.0":
-  version: 9.28.0
-  resolution: "@eslint/js@npm:9.28.0"
-  checksum: 10c0/5a6759542490dd9f778993edfbc8d2f55168fd0f7336ceed20fe3870c65499d72fc0bca8d1ae00ea246b0923ea4cba2e0758a8a5507a3506ddcf41c92282abb8
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.29.0":
+"@eslint/js@npm:9.29.0, @eslint/js@npm:~9.29.0":
   version: 9.29.0
   resolution: "@eslint/js@npm:9.29.0"
   checksum: 10c0/d0ccf37063fa27a3fae9347cb044f84ca10b5a2fa19ffb2b3fedf3b96843ac1ff359ea9f0ab0e80f2f16fda4cb0dc61ea0fed0375090f050fe0a029e7d6de3a3
@@ -896,58 +878,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/console@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/console@npm:30.0.0"
+"@jest/console@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/console@npm:30.0.2"
   dependencies:
-    "@jest/types": "npm:30.0.0"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
-    jest-message-util: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
+    jest-message-util: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
     slash: "npm:^3.0.0"
-  checksum: 10c0/57fc88b8b63086eaa34312f6d42b9736a85ecbecf1bb6bc5e4f6556243df4708dfa2ad7b2b4043ae7553b6131ebf54825f57d9a2caa74a151953be641acc75d0
+  checksum: 10c0/24ef330985ff020963e1d82088d0c3a7fbe981a62bc810b7afb71e6565b8c6cbcb5e789d494d3973762efc2dc351770ad05b96568517d370ad9cd8fd33f5acd0
   languageName: node
   linkType: hard
 
-"@jest/core@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/core@npm:30.0.0"
+"@jest/core@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/core@npm:30.0.2"
   dependencies:
-    "@jest/console": "npm:30.0.0"
-    "@jest/pattern": "npm:30.0.0"
-    "@jest/reporters": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/transform": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/console": "npm:30.0.2"
+    "@jest/pattern": "npm:30.0.1"
+    "@jest/reporters": "npm:30.0.2"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/transform": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     ansi-escapes: "npm:^4.3.2"
     chalk: "npm:^4.1.2"
     ci-info: "npm:^4.2.0"
     exit-x: "npm:^0.2.2"
     graceful-fs: "npm:^4.2.11"
-    jest-changed-files: "npm:30.0.0"
-    jest-config: "npm:30.0.0"
-    jest-haste-map: "npm:30.0.0"
-    jest-message-util: "npm:30.0.0"
-    jest-regex-util: "npm:30.0.0"
-    jest-resolve: "npm:30.0.0"
-    jest-resolve-dependencies: "npm:30.0.0"
-    jest-runner: "npm:30.0.0"
-    jest-runtime: "npm:30.0.0"
-    jest-snapshot: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-validate: "npm:30.0.0"
-    jest-watcher: "npm:30.0.0"
+    jest-changed-files: "npm:30.0.2"
+    jest-config: "npm:30.0.2"
+    jest-haste-map: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-regex-util: "npm:30.0.1"
+    jest-resolve: "npm:30.0.2"
+    jest-resolve-dependencies: "npm:30.0.2"
+    jest-runner: "npm:30.0.2"
+    jest-runtime: "npm:30.0.2"
+    jest-snapshot: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-validate: "npm:30.0.2"
+    jest-watcher: "npm:30.0.2"
     micromatch: "npm:^4.0.8"
-    pretty-format: "npm:30.0.0"
+    pretty-format: "npm:30.0.2"
     slash: "npm:^3.0.0"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 10c0/b0894f5e9b0a9b50067f2b8ee5ce972aae48cb4b93528aa5f39616fa53cf894b6a35c8e51073ed5bccd1d92d79874917ef13f4e605bb27bd94b941d6b34c9ee0
+  checksum: 10c0/2e56665365dfe1f3dbfe78c46a8c6de2ad9406893c5bbb8d39c116c3a7c1b14e3a8a8f74ec6d17308c0bcb6bf86756209e9e29f4bc0d4c701ab44b2f8bbee2ac
   languageName: node
   linkType: hard
 
@@ -958,15 +940,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/environment@npm:30.0.0"
+"@jest/diff-sequences@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/diff-sequences@npm:30.0.1"
+  checksum: 10c0/3a840404e6021725ef7f86b11f7b2d13dd02846481264db0e447ee33b7ee992134e402cdc8b8b0ac969d37c6c0183044e382dedee72001cdf50cfb3c8088de74
+  languageName: node
+  linkType: hard
+
+"@jest/environment@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/environment@npm:30.0.2"
   dependencies:
-    "@jest/fake-timers": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/fake-timers": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
-    jest-mock: "npm:30.0.0"
-  checksum: 10c0/943d59b96ef95d87827d9241bd3d336fcf6869eddab06ac5615b26322bddccd630d60ff914d50e5b5c517e7a15623e155735c08a5e58489cbc1a61390236364b
+    jest-mock: "npm:30.0.2"
+  checksum: 10c0/b16683337bd61f4c1134035c9221f92b958b79965be16d4105a5008169a22705edb004ef06cb10f42cbc23464b69bbc0eb5746d60931f764b2cbf2455477b430
   languageName: node
   linkType: hard
 
@@ -979,27 +968,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/expect@npm:30.0.0"
+"@jest/expect-utils@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/expect-utils@npm:30.0.2"
   dependencies:
-    expect: "npm:30.0.0"
-    jest-snapshot: "npm:30.0.0"
-  checksum: 10c0/f11de81beecfe965a5c6f84da8c764330c8e8c756f7338db75bc62397b6b292f4216319801039070faf89643d9eebe87b73dd1b00bc308c7253d07ae612fab11
+    "@jest/get-type": "npm:30.0.1"
+  checksum: 10c0/70d40c364170bb3cfabfb53bf24605f0bcb076c3968bdd3a9d9b9e102d3b918e666c53c1866e6bf5d6a0552aa6f7b611e406d5967723a6f8e99f235d01c94469
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/fake-timers@npm:30.0.0"
+"@jest/expect@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/expect@npm:30.0.2"
   dependencies:
-    "@jest/types": "npm:30.0.0"
+    expect: "npm:30.0.2"
+    jest-snapshot: "npm:30.0.2"
+  checksum: 10c0/b55ade7cee77b4650ea141de9a34fcd37e74a3662689673c40b941a7c2d0ebbdf215f7f45fb3537e14afb04d90187d9ea0b1030e83a2885995fdbf5ec7edd704
+  languageName: node
+  linkType: hard
+
+"@jest/fake-timers@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/fake-timers@npm:30.0.2"
+  dependencies:
+    "@jest/types": "npm:30.0.1"
     "@sinonjs/fake-timers": "npm:^13.0.0"
     "@types/node": "npm:*"
-    jest-message-util: "npm:30.0.0"
-    jest-mock: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-  checksum: 10c0/938cdb91113f9e2d5852ae4f8ad509799cdfc3f14bbe1bb0ddb1fba32e38c49876536ba3d395a5c16c8970ac45be1d2e2f4992a7ff5708e6da42ec7a76730564
+    jest-message-util: "npm:30.0.2"
+    jest-mock: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+  checksum: 10c0/896e727a1146948780998d62e7807214f9e2b0a724e283f19baca4dfe326fb8fb885244eee6d201bc5e1385336c176c093179f080e0fae03b20ec25c02604352
   languageName: node
   linkType: hard
 
@@ -1010,15 +1008,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/globals@npm:30.0.0"
+"@jest/get-type@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/get-type@npm:30.0.1"
+  checksum: 10c0/92437ae42d0df57e8acc2d067288151439db4752cde4f5e680c73c8a6e34568bbd8c1c81a2f2f9a637a619c2aac8bc87553fb80e31475b59e2ed789a71e5e540
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/globals@npm:30.0.2"
   dependencies:
-    "@jest/environment": "npm:30.0.0"
-    "@jest/expect": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
-    jest-mock: "npm:30.0.0"
-  checksum: 10c0/3dd1244e3115d0f0aa61f4850324e5f85d5117bd09458d09c1dca34989d16d46d8c0b7e6ac9b128cc9c3dab38cdd5a1145c0786b7fb2eb644e854e7da23bab06
+    "@jest/environment": "npm:30.0.2"
+    "@jest/expect": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
+    jest-mock: "npm:30.0.2"
+  checksum: 10c0/f8862d8bf64e29073c117e02610774578a38913bcdeb4461c18a32accc55c62868052b50f71fccd40f2ddf8e28ab2474d719386fb4ddd0fc8b29d64cae4c712d
   languageName: node
   linkType: hard
 
@@ -1032,15 +1037,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/reporters@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/reporters@npm:30.0.0"
+"@jest/pattern@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/pattern@npm:30.0.1"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.0.1"
+  checksum: 10c0/32c5a7bfb6c591f004dac0ed36d645002ed168971e4c89bd915d1577031672870032594767557b855c5bc330aa1e39a2f54bf150d2ee88a7a0886e9cb65318bc
+  languageName: node
+  linkType: hard
+
+"@jest/reporters@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/reporters@npm:30.0.2"
   dependencies:
     "@bcoe/v8-coverage": "npm:^0.2.3"
-    "@jest/console": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/transform": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/console": "npm:30.0.2"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/transform": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
@@ -1053,9 +1068,9 @@ __metadata:
     istanbul-lib-report: "npm:^3.0.0"
     istanbul-lib-source-maps: "npm:^5.0.0"
     istanbul-reports: "npm:^3.1.3"
-    jest-message-util: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-worker: "npm:30.0.0"
+    jest-message-util: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-worker: "npm:30.0.2"
     slash: "npm:^3.0.0"
     string-length: "npm:^4.0.2"
     v8-to-istanbul: "npm:^9.0.1"
@@ -1064,7 +1079,7 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 10c0/997699c7f41ac8a8c3dce8f5948147f8e1bb2adf64428880b949c1e755e54985987b1dda5151ba7bcba98164a1463b3125e7262ca17020dd9ad6ef2540515b81
+  checksum: 10c0/4931fd1f3ae1236fba8f6068b8949b3788fe367ff2eaaa88293988344f50dcb5c15a4063a65cc4485546504bb3b85e2e6667c68acca249d3597b97425bbc2ee5
   languageName: node
   linkType: hard
 
@@ -1077,6 +1092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/schemas@npm:30.0.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/27977359edc4b33293af7c85c53de5014a87c29b9ab98b0a827fedfc6635abdb522aad8c3ff276080080911f519699b094bd6f4e151b43f0cc5856ccc83c04a7
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
@@ -1086,73 +1110,73 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/snapshot-utils@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/snapshot-utils@npm:30.0.0"
+"@jest/snapshot-utils@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/snapshot-utils@npm:30.0.1"
   dependencies:
-    "@jest/types": "npm:30.0.0"
+    "@jest/types": "npm:30.0.1"
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
     natural-compare: "npm:^1.4.0"
-  checksum: 10c0/5a03bf72f3c690c84cdd6b4790e9321f42d76fcef6e5f17b2d8124864c4c7130e7b16b8257fec6b361bbb72baa2e0e98dba294f4f9768519b61360c5e03c5acc
+  checksum: 10c0/a90f09733ca98e695bc2850afdbb0a9d958f4f8805b0e5420cba210422c5bfeb097de57bf66436006f3d5cc3da4109e1e65f6c3e2947474a4911f4d22a8496e8
   languageName: node
   linkType: hard
 
-"@jest/source-map@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/source-map@npm:30.0.0"
+"@jest/source-map@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/source-map@npm:30.0.1"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     callsites: "npm:^3.1.0"
     graceful-fs: "npm:^4.2.11"
-  checksum: 10c0/350ff4c40bd70249d7f1706726e2541e1b62ea525ffbfcfc07888dcab92afa06d6b34bea98d4295183b96cadfd8364096eceb2ff3225ae1dbafae7f05e6a727d
+  checksum: 10c0/e7bda2786fc9f483d9dd7566c58c4bd948830997be862dfe80a3ae5550ff3f84753abb52e705d02ebe9db9f34ba7ebec4c2db11882048cdeef7a66f6332b3897
   languageName: node
   linkType: hard
 
-"@jest/test-result@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/test-result@npm:30.0.0"
+"@jest/test-result@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/test-result@npm:30.0.2"
   dependencies:
-    "@jest/console": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/console": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/istanbul-lib-coverage": "npm:^2.0.6"
     collect-v8-coverage: "npm:^1.0.2"
-  checksum: 10c0/33a05e57855e5b1a7b1dbb6b297c7abf30c54190a1497259f45025a8e33945d7206ac84102ec73de5466e14872f6c852ff9c38e5772356e900bafd403b90e67f
+  checksum: 10c0/f2a1d5b3f1c8f786acc76b77c72a73dc314e579a4ea91ad5ad19e9906156ffa17b56a69cab33cffd1d9be32cfc5f98c60a92fceedd4c700280933b8a14de4e35
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/test-sequencer@npm:30.0.0"
+"@jest/test-sequencer@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/test-sequencer@npm:30.0.2"
   dependencies:
-    "@jest/test-result": "npm:30.0.0"
+    "@jest/test-result": "npm:30.0.2"
     graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.0.0"
+    jest-haste-map: "npm:30.0.2"
     slash: "npm:^3.0.0"
-  checksum: 10c0/b2ccc5cfb4742cc336b3c780f36cf041705d7ea9a0a76230878d517f09d93309a4b77695079cacec3e01198a414fb712e8a3d0ecf1c644664c8bee44e14c341e
+  checksum: 10c0/5d6d74a8c530db1fac4ba085b6a27e98b52a196e2d88d53462771f3a8e8165d3f593a3cea28ed73951cbaf95ba80c7389719c58e99cb3700f0ad122376d1430b
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:30.0.0":
-  version: 30.0.0
-  resolution: "@jest/transform@npm:30.0.0"
+"@jest/transform@npm:30.0.2":
+  version: 30.0.2
+  resolution: "@jest/transform@npm:30.0.2"
   dependencies:
     "@babel/core": "npm:^7.27.4"
-    "@jest/types": "npm:30.0.0"
+    "@jest/types": "npm:30.0.1"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     babel-plugin-istanbul: "npm:^7.0.0"
     chalk: "npm:^4.1.2"
     convert-source-map: "npm:^2.0.0"
     fast-json-stable-stringify: "npm:^2.1.0"
     graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.0.0"
-    jest-regex-util: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
+    jest-haste-map: "npm:30.0.2"
+    jest-regex-util: "npm:30.0.1"
+    jest-util: "npm:30.0.2"
     micromatch: "npm:^4.0.8"
     pirates: "npm:^4.0.7"
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^5.0.1"
-  checksum: 10c0/7452a5bc991a26d39feb1b06e33114664af52ed4b004e786aa5fabc75f0e270d53c80b424fa720905ab6fe59062f8e68740b5122bed72354cc6e33a177948cfc
+  checksum: 10c0/2ab4c049b2c4851dd7abc9f837565c7b3feb5d395955608d929c5caffc0052955a0216c20bf5db1eebef9b9a888cec508a1ea3b6237648cc1f77fea00b2321dd
   languageName: node
   linkType: hard
 
@@ -1168,6 +1192,21 @@ __metadata:
     "@types/yargs": "npm:^17.0.33"
     chalk: "npm:^4.1.2"
   checksum: 10c0/f34f5aff00680c408a2b35e70b486d157a6c1f8006efda31ca4b2f94f727ce1875dbd09edb89b444de8f8184f5009bc0c9509ab7685485bd13337745d8f4def7
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/types@npm:30.0.1"
+  dependencies:
+    "@jest/pattern": "npm:30.0.1"
+    "@jest/schemas": "npm:30.0.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10c0/407469331e74f9bb1ffd40202c3a8cece2fd07ba535adeb60557bdcee13713cf2f14cf78869ba7ef50a7e6fe0ed7cc97ec775056dd640fc0a332e8fbfaec1ee8
   languageName: node
   linkType: hard
 
@@ -1378,9 +1417,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin@npm:~4.4.0":
-  version: 4.4.0
-  resolution: "@stylistic/eslint-plugin@npm:4.4.0"
+"@stylistic/eslint-plugin@npm:~4.4.1":
+  version: 4.4.1
+  resolution: "@stylistic/eslint-plugin@npm:4.4.1"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.32.1"
     eslint-visitor-keys: "npm:^4.2.0"
@@ -1389,7 +1428,7 @@ __metadata:
     picomatch: "npm:^4.0.2"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/f255e40d8a9bcbeacc4292ee19709295da7f6e686753beabed8b9d0c5ebbb3aee968bf1bea8369feb83b81bfb3e07339bcbe143e349219d240188cc862133ae3
+  checksum: 10c0/94160bfc172a3934dd35be87887f43f7e3ffe9d1645096860a4e4c61877bb0fb62eb20a90e50ad74767ee794ed10f334f7165952cf9bcbd8bae6b80dc10c0d62
   languageName: node
   linkType: hard
 
@@ -1402,27 +1441,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/eslint-config@npm:^1.1.17":
-  version: 1.1.17
-  resolution: "@terascope/eslint-config@npm:1.1.17"
+"@terascope/eslint-config@npm:^1.1.18":
+  version: 1.1.18
+  resolution: "@terascope/eslint-config@npm:1.1.18"
   dependencies:
-    "@eslint/compat": "npm:~1.2.9"
-    "@eslint/js": "npm:~9.28.0"
-    "@stylistic/eslint-plugin": "npm:~4.4.0"
-    "@typescript-eslint/eslint-plugin": "npm:~8.33.1"
-    "@typescript-eslint/parser": "npm:~8.33.1"
-    eslint: "npm:~9.28.0"
+    "@eslint/compat": "npm:~1.3.0"
+    "@eslint/js": "npm:~9.29.0"
+    "@stylistic/eslint-plugin": "npm:~4.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:~8.34.1"
+    "@typescript-eslint/parser": "npm:~8.34.1"
+    eslint: "npm:~9.29.0"
     eslint-plugin-import: "npm:~2.31.0"
-    eslint-plugin-jest: "npm:~28.12.0"
+    eslint-plugin-jest: "npm:~28.14.0"
     eslint-plugin-jest-dom: "npm:~5.5.0"
     eslint-plugin-jsx-a11y: "npm:~6.10.2"
     eslint-plugin-react: "npm:~7.37.5"
     eslint-plugin-react-hooks: "npm:~5.2.0"
-    eslint-plugin-testing-library: "npm:~7.3.0"
+    eslint-plugin-testing-library: "npm:~7.5.3"
     globals: "npm:~16.2.0"
     typescript: "npm:~5.8.3"
-    typescript-eslint: "npm:~8.33.1"
-  checksum: 10c0/44be4adc6165e4ee3002864d056ce67f52e0ff0ac9514bc4bbe4be282d7149b5ad0000b6b505a2ec5432c75e6d184081d17e19fef63c0e038f74410781c6e58a
+    typescript-eslint: "npm:~8.34.1"
+  checksum: 10c0/0b71efe6fb3fa8647ebd7a17be667fb12d7509db86dde8581f90331c81b318a7e126d845f20cb37b1f1de91a5f6391650a6672b13e6f62aa8df0cd300921b067
   languageName: node
   linkType: hard
 
@@ -1430,7 +1469,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terascope/fetch-github-release@workspace:."
   dependencies:
-    "@terascope/eslint-config": "npm:^1.1.17"
+    "@terascope/eslint-config": "npm:^1.1.18"
     "@types/jest": "npm:^30.0.0"
     "@types/multi-progress": "npm:^2.0.6"
     "@types/node": "npm:^24.0.3"
@@ -1439,7 +1478,7 @@ __metadata:
     eslint: "npm:^9.29.0"
     extract-zip: "npm:^2.0.1"
     got: "npm:14.4.7"
-    jest: "npm:^30.0.0"
+    jest: "npm:^30.0.2"
     jest-extended: "npm:^6.0.0"
     multi-progress: "npm:^4.0.0"
     nock: "npm:^14.0.5"
@@ -1661,40 +1700,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.33.1, @typescript-eslint/eslint-plugin@npm:~8.33.1":
-  version: 8.33.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.33.1"
+"@typescript-eslint/eslint-plugin@npm:8.34.1, @typescript-eslint/eslint-plugin@npm:~8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.34.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.33.1"
-    "@typescript-eslint/type-utils": "npm:8.33.1"
-    "@typescript-eslint/utils": "npm:8.33.1"
-    "@typescript-eslint/visitor-keys": "npm:8.33.1"
+    "@typescript-eslint/scope-manager": "npm:8.34.1"
+    "@typescript-eslint/type-utils": "npm:8.34.1"
+    "@typescript-eslint/utils": "npm:8.34.1"
+    "@typescript-eslint/visitor-keys": "npm:8.34.1"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.33.1
+    "@typescript-eslint/parser": ^8.34.1
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/35544068f175ca25296b42d0905065b40653a92c62e55414be68f62ddab580d7d768ee3c1276195fd8b8dd49de738ab7b41b8685e6fe2cd341cfca7320569166
+  checksum: 10c0/f1c9f25e4fe4b59622312dfa0ca1e80fa7945296ba5c04362a5fda084a17e23a6b98dac331f5a13bcb1ba34a2b598a3f5c41aa288f0c51fe60196e912954e56a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.33.1, @typescript-eslint/parser@npm:~8.33.1":
-  version: 8.33.1
-  resolution: "@typescript-eslint/parser@npm:8.33.1"
+"@typescript-eslint/parser@npm:8.34.1, @typescript-eslint/parser@npm:~8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/parser@npm:8.34.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.33.1"
-    "@typescript-eslint/types": "npm:8.33.1"
-    "@typescript-eslint/typescript-estree": "npm:8.33.1"
-    "@typescript-eslint/visitor-keys": "npm:8.33.1"
+    "@typescript-eslint/scope-manager": "npm:8.34.1"
+    "@typescript-eslint/types": "npm:8.34.1"
+    "@typescript-eslint/typescript-estree": "npm:8.34.1"
+    "@typescript-eslint/visitor-keys": "npm:8.34.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/be1c1313c342d956f5adfbd56f79865894cc9cabf93992515a690559c3758538868270671b222f90e4cabc2dcab82256aeb3ccea7502de9cc69e47b9b17ed45f
+  checksum: 10c0/bf8070245d53ef6926ff6630bb72f245923f545304e2a61508fb944802a83fed8eab961d9010956d07999d51afdfbbec82aea9d6185295551a7c17c00d759183
   languageName: node
   linkType: hard
 
@@ -1708,6 +1747,19 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
   checksum: 10c0/b2ff7653aef4648bdff8aafc69b9de434184827216709f8a36427536ac7082a8adf1c5ac12a0a2bb023b46dfad8f6fee238028acc94af622956af7f22362de6f
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/project-service@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/project-service@npm:8.34.1"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.34.1"
+    "@typescript-eslint/types": "npm:^8.34.1"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/9333a890625f6777054db17a6b299281ae7502bb7615261d15b885a75b8cf65fc91591389c93b37ecd14b651d8e94851dac8718e5dcc8ed0600533535dae855c
   languageName: node
   linkType: hard
 
@@ -1731,6 +1783,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.34.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.34.1"
+    "@typescript-eslint/visitor-keys": "npm:8.34.1"
+  checksum: 10c0/2af608fa3900f4726322e33bf4f3a376fdace3ac0f310cf7d9256bbc2905c3896138176a47dd195d2c2229f27fe43f5deb4bc7729db2eb18389926dedea78077
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.33.1, @typescript-eslint/tsconfig-utils@npm:^8.33.1":
   version: 8.33.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.33.1"
@@ -1740,18 +1802,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.33.1":
-  version: 8.33.1
-  resolution: "@typescript-eslint/type-utils@npm:8.33.1"
+"@typescript-eslint/tsconfig-utils@npm:8.34.1, @typescript-eslint/tsconfig-utils@npm:^8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.34.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/8d1ead8b7c279b48e2ed96f083ec119a9aeea1ca9cdd40576ec271b996b9fd8cfa0ddb0aafbb4e14bc27fc62c69c5be66d39b1de68eab9ddd7f1861da267423d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/type-utils@npm:8.34.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.33.1"
-    "@typescript-eslint/utils": "npm:8.33.1"
+    "@typescript-eslint/typescript-estree": "npm:8.34.1"
+    "@typescript-eslint/utils": "npm:8.34.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/59843eeb7c652306d130104d7cb0f7dea1cc95a6cf6345609efbae130f24e3c4a9472780332af4247337e152b7955540b15fd9b907c04a5d265b888139818266
+  checksum: 10c0/502a2cdfe47f1f34206c747b5a70e0242dd99f570511db3dda9c5f999d9abadfbbb1dfa82a1fa437a1689d232715412e61c97d95f19c9314ba5ad23196b4096d
   languageName: node
   linkType: hard
 
@@ -1766,6 +1837,13 @@ __metadata:
   version: 8.33.1
   resolution: "@typescript-eslint/types@npm:8.33.1"
   checksum: 10c0/3083c184c882475eed1f9d1a8961dad30ef834c662bc826ff9a959ff1eed49aad21a73b2b93c4062799feafff5f5f24aebb1df17e198808aa19d4c8de1e64095
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.34.1, @typescript-eslint/types@npm:^8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/types@npm:8.34.1"
+  checksum: 10c0/db1b3dce6a70b28ddb13c76fbb5983240d9395656df5f7cbd99bfd9905e39c0dab2132870f01dbc406b48739c437f7d344a879a824cedaba81b91a53110dc23a
   languageName: node
   linkType: hard
 
@@ -1807,18 +1885,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.33.1, @typescript-eslint/utils@npm:^8.32.1":
-  version: 8.33.1
-  resolution: "@typescript-eslint/utils@npm:8.33.1"
+"@typescript-eslint/typescript-estree@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.34.1"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.34.1"
+    "@typescript-eslint/tsconfig-utils": "npm:8.34.1"
+    "@typescript-eslint/types": "npm:8.34.1"
+    "@typescript-eslint/visitor-keys": "npm:8.34.1"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.1.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/4ee7249db91b9840361f34f80b7b6d646a3af159c7298d79a33d8a11c98792fd3a395343e5e17e0fa29529e8f0113bac8baadcef90d1e140bd736a48f0485042
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/utils@npm:8.34.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.33.1"
-    "@typescript-eslint/types": "npm:8.33.1"
-    "@typescript-eslint/typescript-estree": "npm:8.33.1"
+    "@typescript-eslint/scope-manager": "npm:8.34.1"
+    "@typescript-eslint/types": "npm:8.34.1"
+    "@typescript-eslint/typescript-estree": "npm:8.34.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/12263df6eb32e8175236ad899687c062b50cfe4a0e66307d25ad2bf85a3e911faacbfbea4df180a59ebb5913fe1cc1f53fe3914695c7d802dd318bbc846fea26
+  checksum: 10c0/e3085877f7940c02a37653e6bc52ac6cde115e755b1f788fe4331202f371b3421cc4d0878c7d3eb054e14e9b3a064496a707a73eac471cb2b73593b9e9d4b998
   languageName: node
   linkType: hard
 
@@ -1834,6 +1932,21 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
   checksum: 10c0/cd15c4919f02899fd3975049a0a051a1455332a108c085a3e90ae9872e2cddac7f20a9a2c616f1366fca84274649e836ad6a437c9c5ead0bdabf5a123d12403f
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^8.32.1":
+  version: 8.33.1
+  resolution: "@typescript-eslint/utils@npm:8.33.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.7.0"
+    "@typescript-eslint/scope-manager": "npm:8.33.1"
+    "@typescript-eslint/types": "npm:8.33.1"
+    "@typescript-eslint/typescript-estree": "npm:8.33.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/12263df6eb32e8175236ad899687c062b50cfe4a0e66307d25ad2bf85a3e911faacbfbea4df180a59ebb5913fe1cc1f53fe3914695c7d802dd318bbc846fea26
   languageName: node
   linkType: hard
 
@@ -1854,6 +1967,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.33.1"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/3eb99072e7c2741d5dfc38945d1e7617b15ed10d06b24658a6e919e4153983b3d3c5f5f775ce140f83a84dbde219948d187de97defb09c1a91f3cf0a96704a94
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.34.1":
+  version: 8.34.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.34.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.34.1"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/0e5a9b3d93905d16d3cf8cb5fb346dcc6f760482eb7d0ac209aefc09a32f78ef28a687634df6ad08e81fb3e1083e8805f34472de6bbc501c0105ad654d518f40
   languageName: node
   linkType: hard
 
@@ -2288,20 +2411,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:30.0.0":
-  version: 30.0.0
-  resolution: "babel-jest@npm:30.0.0"
+"babel-jest@npm:30.0.2":
+  version: 30.0.2
+  resolution: "babel-jest@npm:30.0.2"
   dependencies:
-    "@jest/transform": "npm:30.0.0"
+    "@jest/transform": "npm:30.0.2"
     "@types/babel__core": "npm:^7.20.5"
     babel-plugin-istanbul: "npm:^7.0.0"
-    babel-preset-jest: "npm:30.0.0"
+    babel-preset-jest: "npm:30.0.1"
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
     slash: "npm:^3.0.0"
   peerDependencies:
     "@babel/core": ^7.11.0
-  checksum: 10c0/8a0e1406ccac162851e53b613d2f3851ec6354254155aa656dc83a3fdf7e73914587fadc3819be681b2316e4a5b7775ab1be6ff3b3c6d3f86d0432950cb64937
+  checksum: 10c0/416deec120eea3f870b45166abc8a30ea29b9235d1acb4a2e50a3b7d623f401589621fa6502dcd4abfffbfaa506eccf20dbbef2c5d0eeac1df9344ec8d8de272
   languageName: node
   linkType: hard
 
@@ -2318,14 +2441,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-jest-hoist@npm:30.0.0":
-  version: 30.0.0
-  resolution: "babel-plugin-jest-hoist@npm:30.0.0"
+"babel-plugin-jest-hoist@npm:30.0.1":
+  version: 30.0.1
+  resolution: "babel-plugin-jest-hoist@npm:30.0.1"
   dependencies:
     "@babel/template": "npm:^7.27.2"
     "@babel/types": "npm:^7.27.3"
     "@types/babel__core": "npm:^7.20.5"
-  checksum: 10c0/558f7cf3c6b16861e95d3f8fe946ccbb4c6d4d49f75d7f2dd798596a6342213b2d9206e8e757c26f3c697ff11e41426e93efcaa42206db76b9264a80ee6236d4
+  checksum: 10c0/49087f45c8ac359d68c622f4bd471300376b0ca2b6bd6ecaa1bd254ea87eda8fa3ce6144848e3bbabad337d276474a47e2ac3f6272f82e1f2337924ff49a02bd
   languageName: node
   linkType: hard
 
@@ -2354,15 +2477,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-jest@npm:30.0.0":
-  version: 30.0.0
-  resolution: "babel-preset-jest@npm:30.0.0"
+"babel-preset-jest@npm:30.0.1":
+  version: 30.0.1
+  resolution: "babel-preset-jest@npm:30.0.1"
   dependencies:
-    babel-plugin-jest-hoist: "npm:30.0.0"
+    babel-plugin-jest-hoist: "npm:30.0.1"
     babel-preset-current-node-syntax: "npm:^1.1.0"
   peerDependencies:
     "@babel/core": ^7.11.0
-  checksum: 10c0/d60475573ef195f730e464f587e732b38b7abd1903072cb78b32090e1eae97064ebdb06f6969dc9c2350545629a965ba268ff5f77b255c572467dd8bfce2bf42
+  checksum: 10c0/33da0094965929b1742b02e55272b544f189cd487d55bbba60e68d96d62d48f466264fe51f65950454829d4f2271541f2433e1c1c5e6a7ff5b9e91f1303471b7
   languageName: node
   linkType: hard
 
@@ -3223,9 +3346,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:~28.12.0":
-  version: 28.12.0
-  resolution: "eslint-plugin-jest@npm:28.12.0"
+"eslint-plugin-jest@npm:~28.14.0":
+  version: 28.14.0
+  resolution: "eslint-plugin-jest@npm:28.14.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
   peerDependencies:
@@ -3237,7 +3360,7 @@ __metadata:
       optional: true
     jest:
       optional: true
-  checksum: 10c0/1072070921e0329bd8a369fea6017de930d942387ef325bc656301812d08d8a9dcd862284493d57c0a52b4bd73128f2157e010116f5efe7bf626c61a78f0a2d8
+  checksum: 10c0/da9c99dd8a1a80aa0c126ff4558882451dcee61b7e4c88e2407ac27d0c86fad2951384a4b037748e26f8743890b4628c6917b0760b01b7017c53fb29768584bc
   languageName: node
   linkType: hard
 
@@ -3303,25 +3426,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:~7.3.0":
-  version: 7.3.0
-  resolution: "eslint-plugin-testing-library@npm:7.3.0"
+"eslint-plugin-testing-library@npm:~7.5.3":
+  version: 7.5.3
+  resolution: "eslint-plugin-testing-library@npm:7.5.3"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^8.15.0"
     "@typescript-eslint/utils": "npm:^8.15.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10c0/febd1823838813bf5ebd122d1da97b3059c181a9586cc8b378870d20d27383342c4536ae86d51a4c2a95b1085167cdf951a5c83ff22c6087d7e9357a10e986a5
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "eslint-scope@npm:8.3.0"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^5.2.0"
-  checksum: 10c0/23bf54345573201fdf06d29efa345ab508b355492f6c6cc9e2b9f6d02b896f369b6dd5315205be94b8853809776c4d13353b85c6b531997b164ff6c3328ecf5b
+  checksum: 10c0/f6594a079bd07347bc6fa142e30cdc3d3731680d8a4c294f288ad1eb1b1175c256a64313531b77637d55826a5a714bbce1237fe97a74302e900ccf0449a3fd7b
   languageName: node
   linkType: hard
 
@@ -3356,7 +3469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.29.0":
+"eslint@npm:^9.29.0, eslint@npm:~9.29.0":
   version: 9.29.0
   resolution: "eslint@npm:9.29.0"
   dependencies:
@@ -3403,56 +3516,6 @@ __metadata:
   bin:
     eslint: bin/eslint.js
   checksum: 10c0/75e3f841e0f8b0fa93dbb2ba6ae538bd8b611c3654117bc3dadf90bb009923dfd2c15ec2948dc6e6b8b571317cc125c5cceb9255da8cd644ee740020df645dd8
-  languageName: node
-  linkType: hard
-
-"eslint@npm:~9.28.0":
-  version: 9.28.0
-  resolution: "eslint@npm:9.28.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.2.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.20.0"
-    "@eslint/config-helpers": "npm:^0.2.1"
-    "@eslint/core": "npm:^0.14.0"
-    "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.28.0"
-    "@eslint/plugin-kit": "npm:^0.3.1"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    "@types/json-schema": "npm:^7.0.15"
-    ajv: "npm:^6.12.4"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.3.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.2"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/513ea7e69d88a0905d4ed35cef3a8f31ebce7ca9f2cdbda3474495c63ad6831d52357aad65094be7a144d6e51850980ced7d25efb807e8ab06a427241f7cd730
   languageName: node
   linkType: hard
 
@@ -3544,7 +3607,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:30.0.0, expect@npm:^30.0.0":
+"expect@npm:30.0.2":
+  version: 30.0.2
+  resolution: "expect@npm:30.0.2"
+  dependencies:
+    "@jest/expect-utils": "npm:30.0.2"
+    "@jest/get-type": "npm:30.0.1"
+    jest-matcher-utils: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-mock: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+  checksum: 10c0/c313c2afcee52e3d333ace771f88056230a689f0e5b4bad944841635f028e07c2eb3947568a032391e8c055439accb3b381d4832114a272bbd94bcd9953b1db0
+  languageName: node
+  linkType: hard
+
+"expect@npm:^30.0.0":
   version: 30.0.0
   resolution: "expect@npm:30.0.0"
   dependencies:
@@ -4663,58 +4740,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-changed-files@npm:30.0.0"
+"jest-changed-files@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-changed-files@npm:30.0.2"
   dependencies:
     execa: "npm:^5.1.1"
-    jest-util: "npm:30.0.0"
+    jest-util: "npm:30.0.2"
     p-limit: "npm:^3.1.0"
-  checksum: 10c0/6e0c2ec2d88ecadea815ad782f5ab554d60c5888d8009bf20b7f1e394bac1bb8702d929aa471a3fff41645ff0793f570c4cca7f07c22bd05c66a0ff2200d2442
+  checksum: 10c0/794c9e47c460974f2303631d9ee44845d03f4ccd5240649a5f736aa94af78fa5931022324ab302c577dad6adb442ed17140dee9b9985bbfa0d43cad3048a7350
   languageName: node
   linkType: hard
 
-"jest-circus@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-circus@npm:30.0.0"
+"jest-circus@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-circus@npm:30.0.2"
   dependencies:
-    "@jest/environment": "npm:30.0.0"
-    "@jest/expect": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/environment": "npm:30.0.2"
+    "@jest/expect": "npm:30.0.2"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
     co: "npm:^4.6.0"
     dedent: "npm:^1.6.0"
     is-generator-fn: "npm:^2.1.0"
-    jest-each: "npm:30.0.0"
-    jest-matcher-utils: "npm:30.0.0"
-    jest-message-util: "npm:30.0.0"
-    jest-runtime: "npm:30.0.0"
-    jest-snapshot: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
+    jest-each: "npm:30.0.2"
+    jest-matcher-utils: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-runtime: "npm:30.0.2"
+    jest-snapshot: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
     p-limit: "npm:^3.1.0"
-    pretty-format: "npm:30.0.0"
+    pretty-format: "npm:30.0.2"
     pure-rand: "npm:^7.0.0"
     slash: "npm:^3.0.0"
     stack-utils: "npm:^2.0.6"
-  checksum: 10c0/f6d6d90f184644483904d7eec19a4b47ef78f575e105e061e5645b596d19a712233e36296530a383cb44bc0b6466387132bb4fb8b39589520010907b27ebeccc
+  checksum: 10c0/e9d182797da2af09a8ca8c4bfb9b2cc4c526f5487aefc46916f03597b29fa046ad2ba41e0f163c0ce941db32d8b025c54ebd2198b282deb1013e787595346b83
   languageName: node
   linkType: hard
 
-"jest-cli@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-cli@npm:30.0.0"
+"jest-cli@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-cli@npm:30.0.2"
   dependencies:
-    "@jest/core": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/core": "npm:30.0.2"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     chalk: "npm:^4.1.2"
     exit-x: "npm:^0.2.2"
     import-local: "npm:^3.2.0"
-    jest-config: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-validate: "npm:30.0.0"
+    jest-config: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-validate: "npm:30.0.2"
     yargs: "npm:^17.7.2"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -4723,36 +4800,36 @@ __metadata:
       optional: true
   bin:
     jest: ./bin/jest.js
-  checksum: 10c0/b5e56db010e6a52b95ed84ea255b9c979b4a73dbefdf7763dd2a42d1ba52b417eaf67d15c225890a025495e82467ac33fe5c0cb1b1e46a46a6ccdcd14db7e8d3
+  checksum: 10c0/494d2e524edc66c68cc24f84b1fa5cc2a9b89b0633fef944a10eea3c5e2596fe5abf2ad58fd21929e9a4b8310796c08ff42161084b4c2c91dcc040aa490bf5f9
   languageName: node
   linkType: hard
 
-"jest-config@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-config@npm:30.0.0"
+"jest-config@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-config@npm:30.0.2"
   dependencies:
     "@babel/core": "npm:^7.27.4"
-    "@jest/get-type": "npm:30.0.0"
-    "@jest/pattern": "npm:30.0.0"
-    "@jest/test-sequencer": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
-    babel-jest: "npm:30.0.0"
+    "@jest/get-type": "npm:30.0.1"
+    "@jest/pattern": "npm:30.0.1"
+    "@jest/test-sequencer": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
+    babel-jest: "npm:30.0.2"
     chalk: "npm:^4.1.2"
     ci-info: "npm:^4.2.0"
     deepmerge: "npm:^4.3.1"
     glob: "npm:^10.3.10"
     graceful-fs: "npm:^4.2.11"
-    jest-circus: "npm:30.0.0"
-    jest-docblock: "npm:30.0.0"
-    jest-environment-node: "npm:30.0.0"
-    jest-regex-util: "npm:30.0.0"
-    jest-resolve: "npm:30.0.0"
-    jest-runner: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-validate: "npm:30.0.0"
+    jest-circus: "npm:30.0.2"
+    jest-docblock: "npm:30.0.1"
+    jest-environment-node: "npm:30.0.2"
+    jest-regex-util: "npm:30.0.1"
+    jest-resolve: "npm:30.0.2"
+    jest-runner: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-validate: "npm:30.0.2"
     micromatch: "npm:^4.0.8"
     parse-json: "npm:^5.2.0"
-    pretty-format: "npm:30.0.0"
+    pretty-format: "npm:30.0.2"
     slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
   peerDependencies:
@@ -4766,7 +4843,7 @@ __metadata:
       optional: true
     ts-node:
       optional: true
-  checksum: 10c0/55cfe9e7922221961041ae57dfebe1dca4cad58cdb8b56006f589d37f1524689fe34b3b67c1b7c136ab13b7d62125d214513605e28ee7a4e0fd6f29768887ccc
+  checksum: 10c0/0a0e201326f5c273eff7066d9b3d42ed6a750e1c74e8015a7190cdb403020df5a18a77fdef53fb848f9e8cad83a0d043390dbe51bea5bbb97800551a64676f78
   languageName: node
   linkType: hard
 
@@ -4782,6 +4859,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-diff@npm:30.0.2"
+  dependencies:
+    "@jest/diff-sequences": "npm:30.0.1"
+    "@jest/get-type": "npm:30.0.1"
+    chalk: "npm:^4.1.2"
+    pretty-format: "npm:30.0.2"
+  checksum: 10c0/dada50ab8d4c1c907bb4728963d43d812cc391a114f0361356b0e51dcd9461936f0a6b27a3429cb3adb9164eaa78182667836440298ddab39319a9350b445a43
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^29.0.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
@@ -4794,40 +4883,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-docblock@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-docblock@npm:30.0.0"
+"jest-docblock@npm:30.0.1":
+  version: 30.0.1
+  resolution: "jest-docblock@npm:30.0.1"
   dependencies:
     detect-newline: "npm:^3.1.0"
-  checksum: 10c0/1a02306b1efb524b19ef3541d590df85301e854e0ac515da3fdc9a7bb78fefe08ddc09365b34a029d34ea537402c6edc6cea0446bfc5856af0ed1d1cd6508d00
+  checksum: 10c0/f9bad2651db8afa029867ea7a40f422c9d73c67657360297371846a314a40c8786424be00483261df9137499f52c2af28cd458fbd15a7bf7fac8775b4bcd6ee1
   languageName: node
   linkType: hard
 
-"jest-each@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-each@npm:30.0.0"
+"jest-each@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-each@npm:30.0.2"
   dependencies:
-    "@jest/get-type": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/get-type": "npm:30.0.1"
+    "@jest/types": "npm:30.0.1"
     chalk: "npm:^4.1.2"
-    jest-util: "npm:30.0.0"
-    pretty-format: "npm:30.0.0"
-  checksum: 10c0/9131d5efbdaf4f5f97b5363753f231e21a2ddc6141410f450dafd94c19b6e4fa2120a0749c95f3e72dc1edb40a723a971d2f016c6b75e3a484cc2d69a4ff7197
+    jest-util: "npm:30.0.2"
+    pretty-format: "npm:30.0.2"
+  checksum: 10c0/6fff0a470d08ba3f0149c58266b7e938e3e183398f99065fe937290f1297ca254635f0f4bca6196514f756fac0a9759144b1c7f67bef97cc0b7fa0b96304df9e
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-environment-node@npm:30.0.0"
+"jest-environment-node@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-environment-node@npm:30.0.2"
   dependencies:
-    "@jest/environment": "npm:30.0.0"
-    "@jest/fake-timers": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/environment": "npm:30.0.2"
+    "@jest/fake-timers": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
-    jest-mock: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-validate: "npm:30.0.0"
-  checksum: 10c0/2c53e72398af89c1028b3899c0de68d7bb28c3a47b8a2b93d38bd3bbf47eda1d62f124fc28a7c4ade85fb020332c133b399cca1b48ac6be2d11525d0a0e6d23d
+    jest-mock: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-validate: "npm:30.0.2"
+  checksum: 10c0/e58515d26f13704c3be6281d029c4fa0902172d2a55751205badf0153630520c4e651f7923577e1ab0dfbb64c4fedb1e4b78622b53b3a8d8e0515c1923f3adc3
   languageName: node
   linkType: hard
 
@@ -4855,35 +4944,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-haste-map@npm:30.0.0"
+"jest-haste-map@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-haste-map@npm:30.0.2"
   dependencies:
-    "@jest/types": "npm:30.0.0"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     anymatch: "npm:^3.1.3"
     fb-watchman: "npm:^2.0.2"
     fsevents: "npm:^2.3.3"
     graceful-fs: "npm:^4.2.11"
-    jest-regex-util: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-worker: "npm:30.0.0"
+    jest-regex-util: "npm:30.0.1"
+    jest-util: "npm:30.0.2"
+    jest-worker: "npm:30.0.2"
     micromatch: "npm:^4.0.8"
     walker: "npm:^1.0.8"
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 10c0/8f45fa1e6d42b3e6146df7ea51da31ef39b31255769e0de9791fa11ef6a94a6a82fce4054967d5de6ccfad663ee5f782f64165b968612dd4f910bc396565ba2e
+  checksum: 10c0/6427b6976beb3fd33cae9a516e24f409d0cc0be2afa12a62e95671001a0d0d61662e8b2185027639b2036fe3e3b055e9d9b4dfd2063e787cf2a5d2140da0b80a
   languageName: node
   linkType: hard
 
-"jest-leak-detector@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-leak-detector@npm:30.0.0"
+"jest-leak-detector@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-leak-detector@npm:30.0.2"
   dependencies:
-    "@jest/get-type": "npm:30.0.0"
-    pretty-format: "npm:30.0.0"
-  checksum: 10c0/5dbf16dcaae651386d49556a657773497a555db78c033465d6767ce35db20aeae3aca4e34eb5fbf01bec733df699ed99aee56cc08d5af4c0422999e132a5c7af
+    "@jest/get-type": "npm:30.0.1"
+    pretty-format: "npm:30.0.2"
+  checksum: 10c0/1df28475c40b41024adc6e18af0d3dc8d8d318fdbbf5c3560321fea0af2e0784c57f788b5b152efd83274ab6ea8dc3b36662060a83a2a555ffd8cdf7d628ee76
   languageName: node
   linkType: hard
 
@@ -4896,6 +4985,18 @@ __metadata:
     jest-diff: "npm:30.0.0"
     pretty-format: "npm:30.0.0"
   checksum: 10c0/56869dfddf74252265a51be5a291b6c1148b5d3cb16702a2c7fd80bf3d4967d565927abaceba7ba28be13e749f0d3060e41641b0125fbefc0da0762b795069fd
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-matcher-utils@npm:30.0.2"
+  dependencies:
+    "@jest/get-type": "npm:30.0.1"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.0.2"
+    pretty-format: "npm:30.0.2"
+  checksum: 10c0/6e862dfe259c30f066fe800cc302cad8cdb4ff92dad73538ce099960ecffd5ba119282af933521765ce24fb3d99b5338d7fa64261df08f9e8505350e9d112424
   languageName: node
   linkType: hard
 
@@ -4916,6 +5017,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-message-util@npm:30.0.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@jest/types": "npm:30.0.1"
+    "@types/stack-utils": "npm:^2.0.3"
+    chalk: "npm:^4.1.2"
+    graceful-fs: "npm:^4.2.11"
+    micromatch: "npm:^4.0.8"
+    pretty-format: "npm:30.0.2"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.6"
+  checksum: 10c0/c010d5b7d86e735e2fb4c4a220f57004349f488f5d4663240a7e9f2694d01b5228136540d55036777fde4227b5e0b56f08885b7f69395b295cab878357b1aeb1
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:30.0.0":
   version: 30.0.0
   resolution: "jest-mock@npm:30.0.0"
@@ -4924,6 +5042,17 @@ __metadata:
     "@types/node": "npm:*"
     jest-util: "npm:30.0.0"
   checksum: 10c0/72c0a210ef0492c84e279f14f55f63ca14e8124e2a67047bd8b2841da1428b35b6985bfe88041e1f6fbc50980e7f03b4581009575968ed59f226840c482fa348
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-mock@npm:30.0.2"
+  dependencies:
+    "@jest/types": "npm:30.0.1"
+    "@types/node": "npm:*"
+    jest-util: "npm:30.0.2"
+  checksum: 10c0/7728997c1d654475b88e18b7ba33a2a1b9f89ce33a9082bf2d14dcc3e831f372f80c762e481777886a3a04b4489ea5390ecdeb21c4def57fba5b2c77086a3959
   languageName: node
   linkType: hard
 
@@ -4946,118 +5075,125 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-resolve-dependencies@npm:30.0.0"
-  dependencies:
-    jest-regex-util: "npm:30.0.0"
-    jest-snapshot: "npm:30.0.0"
-  checksum: 10c0/fb844f966aacbff7b31d6a442622417fd01a8da3a915735fd8f3951627307bef652c62e09712c7140d2aefe5a937cdd30928b63ce7a76716cc0d5682867c5596
+"jest-regex-util@npm:30.0.1":
+  version: 30.0.1
+  resolution: "jest-regex-util@npm:30.0.1"
+  checksum: 10c0/f30c70524ebde2d1012afe5ffa5691d5d00f7d5ba9e43d588f6460ac6fe96f9e620f2f9b36a02d0d3e7e77bc8efb8b3450ae3b80ac53c8be5099e01bf54f6728
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-resolve@npm:30.0.0"
+"jest-resolve-dependencies@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-resolve-dependencies@npm:30.0.2"
+  dependencies:
+    jest-regex-util: "npm:30.0.1"
+    jest-snapshot: "npm:30.0.2"
+  checksum: 10c0/2221bff536dce2d3e57d29092e208cb65054d3c8289e5b3be5ee8921ac6059b97a10cb4bf6671a3002f673da3e8ba4a0881080c5125da60084b5cc27175ab471
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-resolve@npm:30.0.2"
   dependencies:
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.0.0"
+    jest-haste-map: "npm:30.0.2"
     jest-pnp-resolver: "npm:^1.2.3"
-    jest-util: "npm:30.0.0"
-    jest-validate: "npm:30.0.0"
+    jest-util: "npm:30.0.2"
+    jest-validate: "npm:30.0.2"
     slash: "npm:^3.0.0"
     unrs-resolver: "npm:^1.7.11"
-  checksum: 10c0/2973acdbd4a954032bc73ee4871bb92d2e40e524c7cf556f039a088d85810f61b867fe1c62d02e3eba82eb80566d22cd4399e89fb03aaace998097e1611893ac
+  checksum: 10c0/33ae69455b1206a926bb6f7dd46cd4b6cbf5e095387078873a05dfb693bef419b93897e052ee68026b31b5e5f537fdcfce42f2d31af0ce7e64a8179ed7882b51
   languageName: node
   linkType: hard
 
-"jest-runner@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-runner@npm:30.0.0"
+"jest-runner@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-runner@npm:30.0.2"
   dependencies:
-    "@jest/console": "npm:30.0.0"
-    "@jest/environment": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/transform": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/console": "npm:30.0.2"
+    "@jest/environment": "npm:30.0.2"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/transform": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
     emittery: "npm:^0.13.1"
     exit-x: "npm:^0.2.2"
     graceful-fs: "npm:^4.2.11"
-    jest-docblock: "npm:30.0.0"
-    jest-environment-node: "npm:30.0.0"
-    jest-haste-map: "npm:30.0.0"
-    jest-leak-detector: "npm:30.0.0"
-    jest-message-util: "npm:30.0.0"
-    jest-resolve: "npm:30.0.0"
-    jest-runtime: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    jest-watcher: "npm:30.0.0"
-    jest-worker: "npm:30.0.0"
+    jest-docblock: "npm:30.0.1"
+    jest-environment-node: "npm:30.0.2"
+    jest-haste-map: "npm:30.0.2"
+    jest-leak-detector: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-resolve: "npm:30.0.2"
+    jest-runtime: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    jest-watcher: "npm:30.0.2"
+    jest-worker: "npm:30.0.2"
     p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
-  checksum: 10c0/b6609d477d4a8e73282688cc1bb4d8fff3d0813f6f8b8ff56072b3dcfbc89908ac272fc862fbdc3bd4b6e089d2b442b6ebd160abba4deabc102eb1ee0d5a3a0a
+  checksum: 10c0/540ec431cfe7240e69e3e2ec3ae6eae5f3a164ab57b406bd397a10260262c53372c8c599d7128aa2414ce6d58863b62456d8b4ad2100ba45f3284ab6c937898b
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-runtime@npm:30.0.0"
+"jest-runtime@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-runtime@npm:30.0.2"
   dependencies:
-    "@jest/environment": "npm:30.0.0"
-    "@jest/fake-timers": "npm:30.0.0"
-    "@jest/globals": "npm:30.0.0"
-    "@jest/source-map": "npm:30.0.0"
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/transform": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/environment": "npm:30.0.2"
+    "@jest/fake-timers": "npm:30.0.2"
+    "@jest/globals": "npm:30.0.2"
+    "@jest/source-map": "npm:30.0.1"
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/transform": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
     cjs-module-lexer: "npm:^2.1.0"
     collect-v8-coverage: "npm:^1.0.2"
     glob: "npm:^10.3.10"
     graceful-fs: "npm:^4.2.11"
-    jest-haste-map: "npm:30.0.0"
-    jest-message-util: "npm:30.0.0"
-    jest-mock: "npm:30.0.0"
-    jest-regex-util: "npm:30.0.0"
-    jest-resolve: "npm:30.0.0"
-    jest-snapshot: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
+    jest-haste-map: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-mock: "npm:30.0.2"
+    jest-regex-util: "npm:30.0.1"
+    jest-resolve: "npm:30.0.2"
+    jest-snapshot: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
     slash: "npm:^3.0.0"
     strip-bom: "npm:^4.0.0"
-  checksum: 10c0/73ec21368b7bcb4d1207f4b04f2edf300fe7b4890adfa4d0622c5f43041990b9e33f9deb4c44a55111c5c0d547462cde5c51f516643d76430ef3d9d0f6728617
+  checksum: 10c0/3d6f6232dc5237824cb2ee6f2c9b394b38a2284804e201ec2959e36ca366650a18dcb86429779d2e27629e185f8039424e7d36789eed238452d79e669650a47f
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-snapshot@npm:30.0.0"
+"jest-snapshot@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-snapshot@npm:30.0.2"
   dependencies:
     "@babel/core": "npm:^7.27.4"
     "@babel/generator": "npm:^7.27.5"
     "@babel/plugin-syntax-jsx": "npm:^7.27.1"
     "@babel/plugin-syntax-typescript": "npm:^7.27.1"
     "@babel/types": "npm:^7.27.3"
-    "@jest/expect-utils": "npm:30.0.0"
-    "@jest/get-type": "npm:30.0.0"
-    "@jest/snapshot-utils": "npm:30.0.0"
-    "@jest/transform": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/expect-utils": "npm:30.0.2"
+    "@jest/get-type": "npm:30.0.1"
+    "@jest/snapshot-utils": "npm:30.0.1"
+    "@jest/transform": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     babel-preset-current-node-syntax: "npm:^1.1.0"
     chalk: "npm:^4.1.2"
-    expect: "npm:30.0.0"
+    expect: "npm:30.0.2"
     graceful-fs: "npm:^4.2.11"
-    jest-diff: "npm:30.0.0"
-    jest-matcher-utils: "npm:30.0.0"
-    jest-message-util: "npm:30.0.0"
-    jest-util: "npm:30.0.0"
-    pretty-format: "npm:30.0.0"
+    jest-diff: "npm:30.0.2"
+    jest-matcher-utils: "npm:30.0.2"
+    jest-message-util: "npm:30.0.2"
+    jest-util: "npm:30.0.2"
+    pretty-format: "npm:30.0.2"
     semver: "npm:^7.7.2"
     synckit: "npm:^0.11.8"
-  checksum: 10c0/2df3ff6de6eda3e1c192fbb33ac5468ae0366107e1f51dc3a2fa6f3f1c092bbc7fb1b3143513d22074adf960fd23757824c122a1bc26f54553d168d1e3c773ab
+  checksum: 10c0/761d68fd27f31e575b75449d44ac6a1eac07d6634caa0bb5f9744d6be9b57992271b6a76b4db33b72ad9de36476ae35170238b65217b4e1c86a66195008a4d65
   languageName: node
   linkType: hard
 
@@ -5075,57 +5211,71 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-validate@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-validate@npm:30.0.0"
+"jest-util@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-util@npm:30.0.2"
   dependencies:
-    "@jest/get-type": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
-    camelcase: "npm:^6.3.0"
+    "@jest/types": "npm:30.0.1"
+    "@types/node": "npm:*"
     chalk: "npm:^4.1.2"
-    leven: "npm:^3.1.0"
-    pretty-format: "npm:30.0.0"
-  checksum: 10c0/c73561360fa36e36626e07c69519e822ae6fd45de93272f176f998dad7798ada9369c047f1efaab01ac96ab1496d72c134e20075a4bf43c87b0e222bc88be8e4
+    ci-info: "npm:^4.2.0"
+    graceful-fs: "npm:^4.2.11"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/07de384790b8e5a5925fba5448fa1475790a5b52271fbf99958c18e468da1af940f8b45e330d87766576cf6c5d1f4f41ce51c976483a5079653d9fcdba8aac8e
   languageName: node
   linkType: hard
 
-"jest-watcher@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-watcher@npm:30.0.0"
+"jest-validate@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-validate@npm:30.0.2"
   dependencies:
-    "@jest/test-result": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/get-type": "npm:30.0.1"
+    "@jest/types": "npm:30.0.1"
+    camelcase: "npm:^6.3.0"
+    chalk: "npm:^4.1.2"
+    leven: "npm:^3.1.0"
+    pretty-format: "npm:30.0.2"
+  checksum: 10c0/9fd1b4f604851187655353eefe8db25db9638dd312d2e29d58868e626d78925edefe94fe2c8eb63305eefd41e5fe7f8aff334e2db9db5aaddeec866f9f6561d8
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-watcher@npm:30.0.2"
+  dependencies:
+    "@jest/test-result": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     "@types/node": "npm:*"
     ansi-escapes: "npm:^4.3.2"
     chalk: "npm:^4.1.2"
     emittery: "npm:^0.13.1"
-    jest-util: "npm:30.0.0"
+    jest-util: "npm:30.0.2"
     string-length: "npm:^4.0.2"
-  checksum: 10c0/2ee05cbaefcb399fbbaf697125bac4ddfbcb5a37f9b2d942eb11e7328a326b3bbd30def06320096ea7d3489499a8617dcefa8d8e25948bba1a8b984ce4d5b97c
+  checksum: 10c0/7cb09da5feaa6c5558e5149406bde354c3e227ef692b5371efe4d13cf566d42a157c04a55f3a201d191afb7ebc49be84b1ed5a744f46497d9ecccc323d8963f5
   languageName: node
   linkType: hard
 
-"jest-worker@npm:30.0.0":
-  version: 30.0.0
-  resolution: "jest-worker@npm:30.0.0"
+"jest-worker@npm:30.0.2":
+  version: 30.0.2
+  resolution: "jest-worker@npm:30.0.2"
   dependencies:
     "@types/node": "npm:*"
     "@ungap/structured-clone": "npm:^1.3.0"
-    jest-util: "npm:30.0.0"
+    jest-util: "npm:30.0.2"
     merge-stream: "npm:^2.0.0"
     supports-color: "npm:^8.1.1"
-  checksum: 10c0/146977e7c4648c9006d2837aa88bb7d9c057fa5cb65feb0356df60c792eaf8dfac28648169b63fb89f96626ec0fa0edaab89594b3b55724b4b31e1ff61c0108c
+  checksum: 10c0/d7d237e763a2f1aed4eba07f977490442a7bb085f7ab63163afa88776804c2644cc05a1e32da9d05a4b895ad22b2e939ef01a90ffb3024b53fc8c73b8ad1d3f1
   languageName: node
   linkType: hard
 
-"jest@npm:^30.0.0":
-  version: 30.0.0
-  resolution: "jest@npm:30.0.0"
+"jest@npm:^30.0.2":
+  version: 30.0.2
+  resolution: "jest@npm:30.0.2"
   dependencies:
-    "@jest/core": "npm:30.0.0"
-    "@jest/types": "npm:30.0.0"
+    "@jest/core": "npm:30.0.2"
+    "@jest/types": "npm:30.0.1"
     import-local: "npm:^3.2.0"
-    jest-cli: "npm:30.0.0"
+    jest-cli: "npm:30.0.2"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -5133,7 +5283,7 @@ __metadata:
       optional: true
   bin:
     jest: ./bin/jest.js
-  checksum: 10c0/2a9de9ddc9c39c3b5b2cbcb1a8c8aa90904e2c9a42aba7930ce86fba43c1b084fa9e29e66deebe8341ae33cd3dd244c175642c0bc4f50a16758bbcab80324ffe
+  checksum: 10c0/e8273807ed9ee06a8b18f3ca64564f2fd609d3f76d52df8f0bd145e19b2e04877a103cd13c15400c11a9a88a7c35219490fe27d371d2b810eac9df9c751b8b7b
   languageName: node
   linkType: hard
 
@@ -6110,6 +6260,17 @@ __metadata:
     ansi-styles: "npm:^5.2.0"
     react-is: "npm:^18.3.1"
   checksum: 10c0/a57269aff3f4c4da44880f93d42b4fdf5405ef8d3b3c535969d4a6ed1914e70ac35fccb648dc980099cd3bef9e9d73a521e59ca073e6c9e704cfb8c6f49e51bb
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:30.0.2":
+  version: 30.0.2
+  resolution: "pretty-format@npm:30.0.2"
+  dependencies:
+    "@jest/schemas": "npm:30.0.1"
+    ansi-styles: "npm:^5.2.0"
+    react-is: "npm:^18.3.1"
+  checksum: 10c0/cf542dc2d0be95e2b1c6e3a397a4fc13fce1c9f8feed6b56165c0d23c7a83423abb6b032ed8e3e1b7c1c0709f9b117dd30b5185f107e58f8766616be6de84850
   languageName: node
   linkType: hard
 
@@ -7129,17 +7290,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:~8.33.1":
-  version: 8.33.1
-  resolution: "typescript-eslint@npm:8.33.1"
+"typescript-eslint@npm:~8.34.1":
+  version: 8.34.1
+  resolution: "typescript-eslint@npm:8.34.1"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.33.1"
-    "@typescript-eslint/parser": "npm:8.33.1"
-    "@typescript-eslint/utils": "npm:8.33.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.34.1"
+    "@typescript-eslint/parser": "npm:8.34.1"
+    "@typescript-eslint/utils": "npm:8.34.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/8b332c565008f975e0905b99705214c4d58f55a4ff7186edda6a77e041a3e2f6fbbb5a78192ff3c77ccb385b624cf222bca0856c138dfd1fe8875aa3dab38f2c
+  checksum: 10c0/6de5d2ce180d1609a8a5383557a2787f17620ebc9a4d84fba9d9240db8005cc3084a7840ebafe532fba9970fe12822ee415615041f3527334fdfc45c411d35b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the following packages:
- devDependencies
  - @terascope/eslint-config from 1.1.17 to 1.1.18
  - jest from 30.0.0 to 30.0.2