### PR TITLE
NPM trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,22 +8,20 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # NOTE: Hard Coded Node Version
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm run setup
-      - run:
-          echo "Check NPM Authentication"
-          npm whoami
       - run: pnpm publish --access public --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v5
 
     - name: Setup Node
       uses: actions/setup-node@v6


### PR DESCRIPTION
Update github actions workflows:
- use latest version of actions
- give publish.yml id-token write permission
- remove npm auth check