### PR TITLE
Fix node version when publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           # NOTE: Hard Coded Node Version
-          node-version: '22.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm run setup
       - run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
Use node 24 in publish.yml workflow. This version comes with npm 11.5.1+ that contains trusted publishing code.